### PR TITLE
Use getStaticPaths fallback

### DIFF
--- a/pages/[slug].tsx
+++ b/pages/[slug].tsx
@@ -75,6 +75,6 @@ export const getStaticPaths = async () => {
 
   return {
     paths: paths?.map((slug) => resolveHref('page', slug)) || [],
-    fallback: false,
+    fallback: true, // check if slug created since last build
   }
 }

--- a/pages/[slug].tsx
+++ b/pages/[slug].tsx
@@ -55,6 +55,7 @@ export const getStaticProps: GetStaticProps<PageProps, Query> = async (ctx) => {
   if (!page) {
     return {
       notFound: true,
+      revalidate: 1, // nonexistant slug might be created later
     }
   }
 

--- a/pages/[slug].tsx
+++ b/pages/[slug].tsx
@@ -67,6 +67,7 @@ export const getStaticProps: GetStaticProps<PageProps, Query> = async (ctx) => {
       draftMode,
       token: draftMode ? readToken : null,
     },
+    revalidate: 10,
   }
 }
 

--- a/pages/projects/[slug].tsx
+++ b/pages/projects/[slug].tsx
@@ -61,6 +61,7 @@ export const getStaticProps: GetStaticProps<PageProps, Query> = async (ctx) => {
   if (!project) {
     return {
       notFound: true,
+      revalidate: 1, // nonexistant slug might be created later
     }
   }
 

--- a/pages/projects/[slug].tsx
+++ b/pages/projects/[slug].tsx
@@ -81,6 +81,6 @@ export const getStaticPaths = async () => {
 
   return {
     paths: paths?.map((slug) => resolveHref('project', slug)) || [],
-    fallback: false,
+    fallback: true, // check if slug created since last build
   }
 }

--- a/pages/projects/[slug].tsx
+++ b/pages/projects/[slug].tsx
@@ -73,6 +73,7 @@ export const getStaticProps: GetStaticProps<PageProps, Query> = async (ctx) => {
       draftMode,
       token: draftMode ? readToken : null,
     },
+    revalidate: 10,
   }
 }
 


### PR DESCRIPTION
Even though the schema allows Sanity users to create pages with slugs, they currently will return 404s until the next build. This change allows those pages to generate between builds.